### PR TITLE
fix: fix cmake config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Application
-if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(LIBRARY_OUTPUT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib")
     add_definitions(-DLOCALLIBPATH="${LIBRARY_OUTPUT_PATH}")
 endif()

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(Qt5Widgets CONFIG REQUIRED)
 add_executable(${APP_NAME} ${SRC})
 
 qt5_add_dbus_adaptor(DAEMON_SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemon.h HomeDaemon homeDaemonAdaptor HomeDaemonAdaptor)
-message(WARNING ${DAEMON_SRC})
 add_executable(${APP_DAEMON_NAME} ${DAEMON_SRC})
 
 # 由于 EXE 只是作为启动程序加载 LIB 使用，一般来说，只需链接 ${LIB_NAME} 既可。

--- a/src/maincomponentplugin/api/API.qml
+++ b/src/maincomponentplugin/api/API.qml
@@ -4,7 +4,6 @@
 
 pragma Singleton
 import QtQuick 2.0
-import QtQuick.LocalStorage 2.0
 
 Item {
     function get(url, callback) {


### PR DESCRIPTION
由于在正式构建中未传递cmake build type参数
导致cmake使用了错误的链接库路径

Log: