### PR TITLE
fix: window control buttons abnormally on High DPI

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -21,5 +21,6 @@ int main(int argc, char *argv[])
 #else
     DAppLoader appLoader(APP_NAME);
 #endif
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     return appLoader.exec(argc, argv);
 }


### PR DESCRIPTION
窗口控制按钮在高分屏上显示异常

Log: