### PR TITLE
fix: window cannot activated in effect off mode

### DIFF
--- a/src/dbusservice/com.deepin.Home.Daemon.xml
+++ b/src/dbusservice/com.deepin.Home.Daemon.xml
@@ -8,6 +8,7 @@
     <signal name="exited">
     </signal>
     <signal name="showMainWindow">
+      <arg name="isIconClick" type="b" direction="out"/>
     </signal>
     <method name="getMachineID">
       <arg type="s" direction="out"/>

--- a/src/main/homeDaemon.cpp
+++ b/src/main/homeDaemon.cpp
@@ -55,10 +55,13 @@ void HomeDaemon::initSysTrayIcon()
     m_sysTrayIcon->setToolTip(tr("Deepin Home"));
     // 显示主窗口
     auto showMainAction = new QAction(tr("Show main window"), this);
-    connect(m_sysTrayIcon, &QSystemTrayIcon::activated, showMainAction, &QAction::triggered);
+    connect(m_sysTrayIcon, &QSystemTrayIcon::activated, this, [this] {
+        QProcess::startDetached("deepin-home", QStringList());
+        emit showMainWindow(true);
+    });
     connect(showMainAction, &QAction::triggered, this, [this] {
         QProcess::startDetached("deepin-home", QStringList());
-        emit showMainWindow();
+        emit showMainWindow(false);
     });
     // 论坛
     auto bbsAction = new QAction(tr("Communication"), this);

--- a/src/main/homeDaemon.h
+++ b/src/main/homeDaemon.h
@@ -114,7 +114,7 @@ signals:
     // 程序退出时发出信号
     void exited();
     // 显示主窗口时发出信号
-    void showMainWindow();
+    void showMainWindow(bool isIconClick);
 };
 
 #endif // DEEPIN_HOME_DAEMON_H

--- a/src/maincomponentplugin/api/API.qml
+++ b/src/maincomponentplugin/api/API.qml
@@ -12,7 +12,7 @@ Item {
     property int msgCount: 0
     property bool autostart
     signal networkError()
-    signal showMainWindow()
+    signal showMainWindow(bool isIconClick)
 
     function get(url, callback) {
         url = worker.getNode() + url
@@ -122,9 +122,9 @@ Item {
             console.log("message change")
             messageCount()
         }
-        function onShowMainWindow() {
+        function onShowMainWindow(isIconClick) {
             console.log("showMainWindow")
-            showMainWindow()
+            showMainWindow(isIconClick)
         }
     }
 }

--- a/src/maincomponentplugin/index/Index.qml
+++ b/src/maincomponentplugin/index/Index.qml
@@ -293,9 +293,13 @@ Item {
     }
     Connections {
         target: API
-        function onShowMainWindow() {
+        function onShowMainWindow(isIconClick) {
+            // 关闭窗口特效时需要先恢复窗口显示
+            window.showNormal()
             if (window.active) {
-                window.close()
+                if(isIconClick) {
+                    window.close()
+                }
             } else {
                 window.requestActivate()
             }

--- a/src/maincomponentplugin/worker.h
+++ b/src/maincomponentplugin/worker.h
@@ -43,7 +43,7 @@ public slots:
 signals:
     void userInfoChanged();
     void messageChanged();
-    void showMainWindow();
+    void showMainWindow(bool isIconClick);
 };
 
 #endif // WORKER_H


### PR DESCRIPTION
在关闭窗口特效后,无法通过托盘激活最小化的主窗口,因为在无窗口特效模式,会把最小化的窗口消毁,需要先调用showNormal 现在点击托盘菜单"显示主窗口"时不会关闭已激活的窗口

Log:
Signed-off-by: wurongjie <wurongjie@deepin.org>