### PR TITLE
fix: Unable to start after upgrading DTK

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-home (1.0.22) stable; urgency=medium
+  
+  * fix: Unable to start after upgrade DTK
+
+ -- myml <wurongjie@deepin.com>  Tue, 25 Apr 2023 15:02:00 +0800
+
 deepin-home (1.0.21) stable; urgency=medium
   
   * faet: Add app icon to skel desktop

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <DAppLoader>
-#include <DGuiApplicationHelper>
 #include <QDBusConnection>
-#include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
 DQUICK_USE_NAMESPACE
@@ -17,12 +15,6 @@ int main(int argc, char *argv[])
         qDebug() << "DBus Error: register com.deepin.Home";
         return -1;
     }
-    // 亮色主题
-    Dtk::Gui::DGuiApplicationHelper::instance()->setPaletteType(
-        Dtk::Gui::DGuiApplicationHelper::ColorType::LightType);
-    // 高分屏
-    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-
     DAppLoader appLoader(APP_NAME);
 #ifdef PLUGINPATH
     appLoader.addPluginPath(PLUGINPATH);

--- a/src/preloadplugin/preloadplugin.cpp
+++ b/src/preloadplugin/preloadplugin.cpp
@@ -4,6 +4,7 @@
 
 #include "preloadplugin.h"
 #include "../base/const.h"
+#include <DGuiApplicationHelper>
 #include <QGuiApplication>
 #include <QTranslator>
 #include <QUrl>
@@ -28,10 +29,15 @@ QGuiApplication *PreloadPlugin::creatApplication(int &argc, char **argv)
     app->setOrganizationName("deepin");
     app->setOrganizationDomain("deepin.org");
     app->setApplicationVersion(APP_VERSION);
+    // 高分屏
+    app->setAttribute(Qt::AA_UseHighDpiPixmaps);
+
     auto translator = new QTranslator(app);
     if (translator->load(QLocale::system().name(), ":/resources/deepin-home/")) {
         app->installTranslator(translator);
     }
-
+    // 固定为亮色主题
+    Dtk::Gui::DGuiApplicationHelper::instance()->setPaletteType(
+        Dtk::Gui::DGuiApplicationHelper::ColorType::LightType);
     return app;
 }


### PR DESCRIPTION
由于兼容问题,深度之家主程序无法在升级DTK启动

Log:
Issue: https://github.com/linuxdeepin/developer-center/issues/4202