### PR TITLE
fix: Feedback Type filter and router conflicts

### DIFF
--- a/src/maincomponentplugin/feedback/List.qml
+++ b/src/maincomponentplugin/feedback/List.qml
@@ -103,8 +103,7 @@ Item {
                 ListElement { text: qsTr("Suggestions"); value: "req" }
             }
             onActivated: {
-                root.type = selectOptions.get(currentIndex).value
-                root.getList(true)
+                Router.showAllFeedback(true, selectOptions.get(currentIndex).value)
             }
             Component.onCompleted:{
                 if(root.type === "bug") {


### PR DESCRIPTION
由于反馈的筛选按钮未记录到路由中,查询反馈详情后再返回,会丢失筛选选项的改动

Log:
Issues: https://github.com/linuxdeepin/developer-center/issues/4707