### PR TITLE
Release 1.2.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-home (1.2.0) unstable; urgency=medium
+
+  * feat: feedback card add 'reproducing' status
+  * feat: show system version in feedback card
+  * fix: feedback type filter and router conflicts(Issue: https://github.com/linuxdeepin/developer-center/issues/4707)
+  * feat: Click on the screenshot to preview(Issue: https://github.com/linuxdeepin/developer-center/issues/4701)
+  * chore: update translation
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 21 Jun 2023 15:48:48 +0800
+
 deepin-home (1.1.7) unstable; urgency=medium
 
   * fix: status text not display

--- a/src/maincomponentplugin/article/Article.qml
+++ b/src/maincomponentplugin/article/Article.qml
@@ -23,6 +23,9 @@ Item {
             id: loading
             visible: true
         }
+        background: FloatingPanel {
+            blurRadius: 25
+        }
         Component.onCompleted: {
             open()
         }

--- a/src/maincomponentplugin/feedback/Card.qml
+++ b/src/maincomponentplugin/feedback/Card.qml
@@ -32,6 +32,7 @@ Rectangle {
     property int view_count: 0
     property int like_count: 0
     property int collect_count: 0
+    property string system_version: ''
 
     signal titleClicked()
     signal likeClicked()
@@ -161,6 +162,24 @@ Rectangle {
                     anchors.centerIn: parent
                 }
             }
+
+            Rectangle {
+                visible: root.system_version
+                Layout.leftMargin: 5
+                width: versionText.width+15
+                height: versionText.height+4
+                border.width: 1
+                border.color: "#b6b6b6"
+                radius: 5
+                Text {
+                    id: versionText
+                    color: "#838383"
+                    text: "V"+root.system_version
+                    font: DTK.fontManager.t6
+                    anchors.centerIn: parent
+                }
+            }
+
             Item {
                 Layout.fillWidth: true
             }

--- a/src/maincomponentplugin/feedback/Card.qml
+++ b/src/maincomponentplugin/feedback/Card.qml
@@ -37,6 +37,7 @@ Rectangle {
     signal titleClicked()
     signal likeClicked()
     signal collectClicked()
+    signal imageClicked(string url)
 
     // 头像预留位置
     Avatar {
@@ -123,6 +124,12 @@ Rectangle {
                     source: root.screenshots[index]
                     width: 48
                     height: 48
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            imageClicked(root.screenshots[index])
+                        }
+                    }
                 }
             }
         }

--- a/src/maincomponentplugin/feedback/Detail.qml
+++ b/src/maincomponentplugin/feedback/Detail.qml
@@ -39,6 +39,7 @@ Item {
                 collect: feedback.collect
                 screenshots: feedback.screenshots
                 avatar: feedback.avatar
+                system_version: feedback.system_version
                 // 点赞按钮点击
                 onLikeClicked: {
                     const callback = () => {

--- a/src/maincomponentplugin/feedback/List.qml
+++ b/src/maincomponentplugin/feedback/List.qml
@@ -152,6 +152,7 @@ Item {
                     like: feedback.like
                     collect: feedback.collect
                     screenshots: feedback.screenshots
+                    system_version: feedback.system_version
                     avatar: feedback.avatar
                     // 点击标题时，进入详情
                     onTitleClicked: {

--- a/src/maincomponentplugin/feedback/List.qml
+++ b/src/maincomponentplugin/feedback/List.qml
@@ -26,6 +26,7 @@ Item {
     // 是否显示“加载更多”按钮
     property bool hasMore: true
     property bool loadMore: false
+    property string imagePreview: ""
 
     ListModel {
         id: feedbackList
@@ -180,6 +181,11 @@ Item {
                             API.likeFeedback(feedback.public_id, callback)
                         }
                     }
+                    onImageClicked: (img) => {
+                        console.log("view screenshot", img)
+                        imagePreview = img
+                        imagePreviewWindow.open()
+                    }
                     // 收藏按钮点击
                     onCollectClicked: {
                         if(!API.isLogin){
@@ -250,6 +256,22 @@ Item {
         icon.height: 18
         onClicked: {
             submitLoader.setSource("Submit.qml", {type: root.type})
+        }
+    }
+    Popup {
+        id: imagePreviewWindow
+        x: 80
+        y: 50
+        width: parent.width-x*2
+        height: parent.height-y*2
+        background: FloatingPanel {
+            blurRadius: 20
+        }
+        Image {
+            width: parent.width
+            height: parent.height
+            fillMode: Image.PreserveAspectFit
+            source: imagePreview
         }
     }
     Loader {

--- a/src/maincomponentplugin/feedback/List.qml
+++ b/src/maincomponentplugin/feedback/List.qml
@@ -103,8 +103,7 @@ Item {
                 ListElement { text: qsTr("Suggestions"); value: "req" }
             }
             onActivated: {
-                root.type = selectOptions.get(currentIndex).value
-                root.getList(true)
+                Router.showAllFeedback(true, selectOptions.get(currentIndex).value)
             }
             Component.onCompleted:{
                 if(root.type === "bug") {

--- a/src/maincomponentplugin/feedback/Status.qml
+++ b/src/maincomponentplugin/feedback/Status.qml
@@ -12,6 +12,7 @@ RoundRectangle {
     property string status
     property var statusiconList: {
         "bug-submit": "/images/status/submit.svg",
+        "bug-reproducing": "/images/status/evaluate.svg",
         "bug-accept": "/images/status/bug-accept.svg",
         "bug-reject": "/images/status/reject.svg",
         "bug-finish": "/images/status/finish.svg",
@@ -23,6 +24,7 @@ RoundRectangle {
     }
     property var statusTextList: {
         "bug-submit": qsTr("Pending"),
+        "bug-reproducing": qsTr("Reproducing"),
         "bug-accept": qsTr("Confirmed"),
         "bug-reject": qsTr("Replied"),
         "bug-finish": qsTr("Resolved"),
@@ -32,8 +34,21 @@ RoundRectangle {
         "req-reject": qsTr("Replied"),
         "req-finish": qsTr("Completed"),
     }
+    property var statusTextTip: {
+        "bug-submit": qsTr("The issue has not been processed and will not be displayed in the public listing."),
+        "bug-reproducing": qsTr("Currently unable to identify the cause; continuous monitoring and investigation are required."),
+        "bug-accept": qsTr("The issue has been reproduced and the root cause has been identified."),
+        "bug-reject": qsTr("The issue is not a bug or of a different nature."),
+        "bug-finish": qsTr("The issue has been resolved and awaiting formal release"),
+        "req-submit": qsTr("The requirement has not been processed and will not be displayed in the public listing"),
+        "req-evaluate": qsTr("The issue has been acknowledged and is being internally assessed"),
+        "req-accept": qsTr("Included in the plans for a future release"),
+        "req-reject": qsTr("The requirement is either not accepted or unable to be addressed"),
+        "req-finish": qsTr("Development work is finished, awaiting formal release"),
+    }
     property var statusBgColor: {
         "bug-submit": "#FFF7E9",
+        "bug-reproducing": "#E0E5FF",
         "bug-accept": "#D6F7FF",
         "bug-reject": "#F5FFE1",
         "bug-finish": "#E1FFF1",
@@ -45,6 +60,7 @@ RoundRectangle {
     }
     property var statusTextColor: {
         "bug-submit": "#B78C45",
+        "bug-reproducing": "#0050A9",
         "bug-accept": "#0261BF",
         "bug-reject": "#17794B",
         "bug-finish": "#17794B",
@@ -72,5 +88,14 @@ RoundRectangle {
         anchors.leftMargin: 6
         text: root.statusTextList["%1-%2".arg(root.type).arg(root.status)]
         anchors.verticalCenter: statusIcon.verticalCenter
+    }
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        ToolTip {
+            delay: 300
+            visible: parent.containsMouse
+            text: root.statusTextTip["%1-%2".arg(root.type).arg(root.status)]
+        }
     }
 }

--- a/src/maincomponentplugin/titlebar/MyTitleBar.qml
+++ b/src/maincomponentplugin/titlebar/MyTitleBar.qml
@@ -99,7 +99,6 @@ TitleBar {
         shadowColor : Qt.rgba(0,0,0,0.03)
         shadowOffsetX : 0
         shadowOffsetY : 4
-        cornerRadius: root.radius
         hollow: true
     }
 }

--- a/translations/deepin-home.ts
+++ b/translations/deepin-home.ts
@@ -262,6 +262,50 @@
         <source>Completed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reproducing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The issue has not been processed and will not be displayed in the public listing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently unable to identify the cause; continuous monitoring and investigation are required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The issue has been reproduced and the root cause has been identified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The issue is not a bug or of a different nature.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The issue has been resolved and awaiting formal release</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The requirement has not been processed and will not be displayed in the public listing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The issue has been acknowledged and is being internally assessed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Included in the plans for a future release</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The requirement is either not accepted or unable to be addressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Development work is finished, awaiting formal release</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Submit</name>

--- a/translations/deepin-home/ca.ts
+++ b/translations/deepin-home/ca.ts
@@ -11,7 +11,7 @@
     </message>
     <message>
         <source>You&apos;ve been making too many requests. Please try again later.</source>
-        <translation type="unfinished"/>
+        <translation>Heu fet massa peticions. Si us plau, torneu-ho a provar més tard.</translation>
     </message>
 </context>
 <context>
@@ -260,6 +260,50 @@
         <source>Completed</source>
         <translation>Completat</translation>
     </message>
+    <message>
+        <source>Reproducing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The issue has not been processed and will not be displayed in the public listing.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Currently unable to identify the cause; continuous monitoring and investigation are required.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The issue has been reproduced and the root cause has been identified.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The issue is not a bug or of a different nature.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The issue has been resolved and awaiting formal release</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The requirement has not been processed and will not be displayed in the public listing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The issue has been acknowledged and is being internally assessed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Included in the plans for a future release</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>The requirement is either not accepted or unable to be addressed</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Development work is finished, awaiting formal release</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>Submit</name>
@@ -412,7 +456,7 @@
     </message>
     <message>
         <source>My Urged</source>
-        <translation type="unfinished"/>
+        <translation>Urgències</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-home/zh_CN.ts
+++ b/translations/deepin-home/zh_CN.ts
@@ -260,6 +260,50 @@
         <source>Completed</source>
         <translation>已完成</translation>
     </message>
+    <message>
+        <source>Reproducing</source>
+        <translation>复现中</translation>
+    </message>
+    <message>
+        <source>The issue has not been processed and will not be displayed in the public listing.</source>
+        <translation>问题未做任何处理，不会出现在需求广场</translation>
+    </message>
+    <message>
+        <source>Currently unable to identify the cause; continuous monitoring and investigation are required.</source>
+        <translation>暂时无法定位，需持续跟进问题</translation>
+    </message>
+    <message>
+        <source>The issue has been reproduced and the root cause has been identified.</source>
+        <translation>明确复现并已经定位原因</translation>
+    </message>
+    <message>
+        <source>The issue is not a bug or of a different nature.</source>
+        <translation>非Bug类型问题</translation>
+    </message>
+    <message>
+        <source>The issue has been resolved and awaiting formal release</source>
+        <translation>完成修复，待推送内容</translation>
+    </message>
+    <message>
+        <source>The requirement has not been processed and will not be displayed in the public listing</source>
+        <translation>需求未做任何处理，不会出现在需求广场</translation>
+    </message>
+    <message>
+        <source>The issue has been acknowledged and is being internally assessed</source>
+        <translation>已经明确接受并转入内部需求评估</translation>
+    </message>
+    <message>
+        <source>Included in the plans for a future release</source>
+        <translation>纳入后期版本规划</translation>
+    </message>
+    <message>
+        <source>The requirement is either not accepted or unable to be addressed</source>
+        <translation>暂不接受或无法处理需求问题</translation>
+    </message>
+    <message>
+        <source>Development work is finished, awaiting formal release</source>
+        <translation>完成开发，待正式发布</translation>
+    </message>
 </context>
 <context>
     <name>Submit</name>


### PR DESCRIPTION
- 添加一个"复现中"的BUG状态,用于说明BUG正在处理
- 鼠标在状态悬浮，显示对反馈状态的说明
- 在用户反馈的左下角添加了用户的系统版本信息
- 修复回复中对反馈引用的解析支持错误（服务端修复的）
- 在反馈列表点击缩略的截图会放大显示
- 修复查看反馈详情后返回到上一层，丢失筛选选项的改动