### PR TITLE
fix: AnimatedImage cannot display png image on the deepin v20

### DIFF
--- a/src/maincomponentplugin/feedback/Card.qml
+++ b/src/maincomponentplugin/feedback/Card.qml
@@ -143,7 +143,22 @@ Rectangle {
                 Layout.preferredHeight: screenshotImg.height
                 AnimatedImage {
                     id: screenshotImg
-                    visible: !root.inList
+                    visible: !root.inList && root.screenshots[index].endsWith(".gif")
+                    width: parent.width
+                    fillMode: Image.PreserveAspectFit
+                    source: root.screenshots[index]
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        hoverEnabled: true
+                        onClicked: {
+                            imageClicked(root.screenshots[index])
+                        }
+                    }
+                }
+                Image {
+                    id: screenshotImgStatic
+                    visible: !root.inList && !root.screenshots[index].endsWith(".gif")
                     width: parent.width
                     fillMode: Image.PreserveAspectFit
                     source: root.screenshots[index]

--- a/src/maincomponentplugin/feedback/List.qml
+++ b/src/maincomponentplugin/feedback/List.qml
@@ -103,7 +103,7 @@ Item {
                 ListElement { text: qsTr("Suggestions"); value: "req" }
             }
             onActivated: {
-                Router.showAllFeedback(true, selectOptions.get(currentIndex).value)
+                Router.showAllFeedback(true, selectOptions.get(currentIndex).value, true)
             }
             Component.onCompleted:{
                 if(root.type === "bug") {

--- a/src/maincomponentplugin/router/Router.qml
+++ b/src/maincomponentplugin/router/Router.qml
@@ -64,11 +64,18 @@ Item {
         routeHistory.push(routeIndex)
     }
     // 显示反馈广场
-    function showAllFeedback(push=true, type="") {
+    // push 为true是会记录到路由，可以避免标签之前反复切换导致路由回退过多
+    // type 类型筛选
+    // overlay 为true时会覆盖上一个路由，避免路由失去参数
+    function showAllFeedback(push=true, type="", overlay = false) {
         const r = clone(routeAllFeedback)
         r.data = {typeFilter: true, type: type}
         routeCurrent = r
         if(push){
+            if (overlay) {
+                routeHistory[routeHistory.length-1] = r
+                return
+            }
             routeHistory.push(r)
         }
     }
@@ -114,7 +121,7 @@ Item {
     function back() {
         routeHistory.pop()
         const r = routeHistory[routeHistory.length-1]
-        console.log("back",JSON.stringify(r.data))
+        console.log("back",JSON.stringify(r))
         routeCurrent = r
     }
 }


### PR DESCRIPTION
可能是因为qt版本比较旧,在deepin v20上无法使用AnimatedImage组件显示png,jpg图片

Issues: https://github.com/linuxdeepin/developer-center/issues/4902

反馈筛选条件变化时覆盖上一个路由,不记录过多路由,避免回退按钮需要多次点击

Issues: https://github.com/linuxdeepin/developer-center/issues/4901