### PR TITLE
fix: application crash caused by event loop blocking

### DIFF
--- a/src/maincomponentplugin/feedback/List.qml
+++ b/src/maincomponentplugin/feedback/List.qml
@@ -90,7 +90,7 @@ Item {
     }
 
     Component.onCompleted: {
-        getList(true)
+        Qt.callLater(getList, true)
     }
 
     // 分类过滤下拉框


### PR DESCRIPTION
修复因事件循环阻塞导致的应用程序崩溃
之前的提交（a7a2ccc）已经对该问题进行了修复，但还有一个被忽略的地方需要修复。