### PR TITLE
fix: When switching tabs quickly, the feedback list is abnormal

### DIFF
--- a/src/maincomponentplugin/feedback/Card.qml
+++ b/src/maincomponentplugin/feedback/Card.qml
@@ -113,7 +113,7 @@ Rectangle {
             onLinkActivated: (link)=> {
                 if(link.startsWith("#")){
                     const public_id = link.slice(1)
-                    API.getFeedback({type: '', offset: 0, limit: 1, ids: [public_id]})
+                    API.getFeedback("", {type: '', offset: 0, limit: 1, ids: [public_id]})
                     return
                 }
                 Qt.openUrlExternally(link)

--- a/src/maincomponentplugin/feedback/Detail.qml
+++ b/src/maincomponentplugin/feedback/Detail.qml
@@ -19,7 +19,7 @@ Item {
     Connections {
         target: API
         // 列表刷新信号
-        function onSignalFeedbackListUpdate(feedbacks) {
+        function onSignalFeedbackListUpdate(reqID, feedbacks) {
             if(feedbacks.length==1) {
                 const feedback = feedbacks[0]
                 API.publicViewFeedback(feedback.public_id)

--- a/src/maincomponentplugin/worker.cpp
+++ b/src/maincomponentplugin/worker.cpp
@@ -288,3 +288,9 @@ QVariant Worker::awaitPromise(QJSValue func)
     // 如果在qml中调用resolve，await返回resolve传递的result
     return promise->await();
 };
+
+// 生成UUID
+QString Worker::genUUID()
+{
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
+}

--- a/src/maincomponentplugin/worker.h
+++ b/src/maincomponentplugin/worker.h
@@ -71,6 +71,8 @@ public slots:
     // 类似js中的await Promise()
     // 可在qml中将异步函数转为同步执行
     QVariant awaitPromise(QJSValue func);
+    // 生成UUID
+    QString genUUID();
 signals:
     void userInfoChanged();
     void messageChanged();


### PR DESCRIPTION
快速切换标签时,反馈列表显示异常
由于网络请求延迟,反馈列表有可能显示其他页面的数据
解决方法是为每个请求创建一个id，仅处理当前id的信号

Log: