### PR TITLE
fix: Email username cannot include '.' symbol

### DIFF
--- a/src/maincomponentplugin/feedback/Submit.qml
+++ b/src/maincomponentplugin/feedback/Submit.qml
@@ -188,7 +188,7 @@ Item {
                 LineEdit {
                     id: emailText
                     selectByMouse: true
-                    validator: RegExpValidator { regExp: /^[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$/ }
+                    validator: RegExpValidator { regExp: /^[a-zA-Z0-9_\.-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$/ }
                     width: win.controlWidth / 2
                     text: ""
                     Text {


### PR DESCRIPTION
修复邮箱'@'符号之前存在'.'符号时无法正常输入

Issues: https://github.com/linuxdeepin/developer-center/issues/5195