### PR TITLE
fix: Some data on the feedback details page is always 0

### DIFF
--- a/src/maincomponentplugin/feedback/Detail.qml
+++ b/src/maincomponentplugin/feedback/Detail.qml
@@ -88,9 +88,9 @@ Item {
                     screenshots: feedback.screenshots
                     avatar: feedback.avatar
                     system_version: feedback.system_version
-                    view_count: view_count
-                    like_count: like_count
-                    collect_count: collect_count
+                    view_count: feedback.view_count
+                    like_count: feedback.like_count
+                    collect_count: feedback.collect_count
                     // 点赞按钮点击
                     onLikeClicked: {
                         if (!API.isLogin) {


### PR DESCRIPTION
修复反馈详情页 浏览量、收藏数量、催促数量始终是 0