### PR TITLE
fix: first startup display error page

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-home (1.5.3) unstable; urgency=medium
+
+  * fix: first startup display error page(Issue: https://github.com/linuxdeepin/developer-center/issues/6400)
+
+ -- myml <wurongjie@deepin.org>  Mon, 11 Dec 2023 15:31:29 +0800
+
 deepin-home (1.5.2) unstable; urgency=medium
 
   * feat: return to homepage when logged out(Issue: https://github.com/linuxdeepin/developer-center/issues/5661)

--- a/src/main/daemon.cpp
+++ b/src/main/daemon.cpp
@@ -17,11 +17,6 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication app(argc, argv);
 
-    QDBusConnection dbus = QDBusConnection::sessionBus();
-    if (!dbus.registerService(DEEPIN_HOME_DAEMON_SERVICE)) {
-        qDebug() << "Register DBus Error" << dbus.lastError().message();
-        return -1;
-    }
     QTranslator translator;
     if (translator.load(QLocale::system().name(), ":/resources/deepin-home-daemon/")) {
         app.installTranslator(&translator);
@@ -37,8 +32,14 @@ int main(int argc, char *argv[])
         }
     }
 
+    QDBusConnection dbus = QDBusConnection::sessionBus();
     new HomeDaemonAdaptor(&daemon);
     dbus.registerObject(DEEPIN_HOME_DAEMON_PATH, &daemon);
+
+    if (!dbus.registerService(DEEPIN_HOME_DAEMON_SERVICE)) {
+        qDebug() << "Register DBus Error" << dbus.lastError().message();
+        return -1;
+    }
 
     daemon.start();
     qDebug() << APP_NAME << "start exec";


### PR DESCRIPTION
修复首次启动显示错误页面
dbus应该先注册对象再注册服务, 否则首次调用dbus有可能报错

Log:
Issues: https://github.com/linuxdeepin/developer-center/issues/6400