### PR TITLE
fix: cannot run in beta3

### DIFF
--- a/src/maincomponentplugin/main.qml
+++ b/src/maincomponentplugin/main.qml
@@ -5,7 +5,6 @@ import "./api"
 import "./router"
 import "./titlebar"
 import QtQuick 2.11
-import QtQuick.Controls 2.4
 import org.deepin.dtk 1.0
 import org.deepin.dtk.impl 1.0 as D
 


### PR DESCRIPTION
quick.controls2没有添加到包依赖
因为没有使用到这个,直接去掉引用即可

Log:
Issues: https://github.com/linuxdeepin/developer-center/issues/6652