### PR TITLE
chore: Release 1.5.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ compile_commands.json
 .vscode/
 build/
 build_dir/
-.linglong-target
+linglong
 .ccls*
 obj-x86_64-linux-gnu
 debian/.debhelper

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-home (1.5.13) unstable; urgency=medium
+
+  * fix: prevent window from maximizing(Issue: https://github.com/linuxdeepin/developer-center/issues/6192)
+  * feat: update desktop i18n
+  * feat: support new version linglong build
+
+ -- myml <wurongjie1@gmail.org>  Mon, 01 Jul 2024 15:29:04 +0800
+
 deepin-home (1.5.12) unstable; urgency=medium
 
   * fix #8885

--- a/deepin-home.desktop
+++ b/deepin-home.desktop
@@ -10,11 +10,13 @@ X-Deepin-TurboType=dtkqml
 # Do not manually modify!
 GenericName[it]=Messaggi
 GenericName[pl]=Wiadomość
+GenericName[pt_BR]=Mensagem
 GenericName[sk]=Správa
 GenericName[tr]=İleti
 GenericName[zh_CN]=消息
 Name[it]=Deepin Home
 Name[pl]=Główna Deepin
+Name[pt_BR]=Comunidade
 Name[sk]=Deepin Domov
 Name[tr]=Deepin Anasayfa
 Name[zh_CN]=深度之家

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,17 +1,20 @@
+version: "1"
 package:
   id: org.deepin.home
   name: "deepin-home"
-  version: 1.5.4
+  version: 1.5.4.0
   kind: app
   description: |
     quick login bbs, bug report.
 
-runtime:
-  id: org.deepin.Runtime
-  version: 23.0
+base: org.deepin.foundation/23.0.0
+runtime: org.deepin.Runtime/23.0.1
 
-source:
-  kind: local
+command: ["deepin-home"]
 
-build:
-  kind: cmake
+build: |
+  set -x
+  cmake -B linglong/build -DCMAKE_INSTALL_LIBDIR="${PREFIX}" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+  cd linglong/build 
+  make -j$(nproc)
+  make install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Application
 include(GNUInstallDirs)
 set(DTK_QML_APP_PLUGIN_PATH ${CMAKE_INSTALL_LIBDIR}/dtkdeclarative/qml-app)
+add_definitions(-DAPP_PLUGIN_PATH="${DTK_QML_APP_PLUGIN_PATH}")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(LIBRARY_OUTPUT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib")

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
     auto oldPath=QDir(DTK_QML_APP_PLUGIN_PATH);
     oldPath.cd("../plugins");
     DAppLoader appLoader(APP_NAME, oldPath.path());
+    appLoader.addPluginPath(oldPath.path());
     #ifdef PLUGINPATH
         appLoader.addPluginPath(PLUGINPATH);
     #endif

--- a/src/preloadplugin/Preload.qml
+++ b/src/preloadplugin/Preload.qml
@@ -31,6 +31,7 @@ ApplicationWindow {
     maximumWidth: width
     height: 800
     minimumHeight: 400
+    maximumHeight: Screen.height - 100
     title: qsTr("Deepin Home")
     flags: Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint
     color: "#fff"


### PR DESCRIPTION
## 禁止点击窗口上边缘触发最大化显示
由于深度之家主页内容较少, 无法自适应窗口大小显示, 限制了窗口最大宽度，如果触发最大化显示, 会显示成高度顶满, 宽度固定, 方形边角的奇怪效果，通过限制窗口最大高度，禁止最大化、全屏等显示效果。
Fix:
  - https://github.com/linuxdeepin/developer-center/issues/6191
  - https://github.com/linuxdeepin/developer-center/issues/6192

## 更新desktop翻译
## 支持使用新版本玲珑构建