### PR TITLE
chore: Release 1.6.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-home (1.6.5) unstable; urgency=medium
+  [ transifex-integration[bot] ]
+  * i18n: update transifex file
+
+ -- myml <wurongjie@deepin.org>  Fri, 22 Nov 2024 17:29:24 +0800
+
 deepin-home (1.6.4) UNRELEASED; urgency=medium
 
   [ transifex-integration[bot] ]


### PR DESCRIPTION
Log: 发布1.6.5版本,更新翻译

## Summary by Sourcery

Publish version 1.6.5 by updating the Debian changelog and refreshing translations

Chores:
- Bump version to 1.6.5 in the Debian changelog
- Update translations for the 1.6.5 release