### PR TITLE
feat: Adapt for DTK6/Qt6 build

### DIFF
--- a/3rdparty/apiserver/client/CMakeLists.txt
+++ b/3rdparty/apiserver/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 
 project(QtDeepinHomeAPI)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,22 +8,25 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core Quick)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Quick)
-find_package(DtkDeclarative REQUIRED)
+# Auto-detect Qt version (tries Qt6 first, falls back to Qt5)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Quick)
+message(STATUS "Found Qt version: ${QT_VERSION_MAJOR}")
 
-# 旧版本Dtk不支持使用cmake find_package 获取版本号， 使用 PkgConfig 来获取版本号
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(DtkDeclarativeModule REQUIRED dtkdeclarative)
-# DtkDeclarative 在 5.6.3 更改了插件的路径和使用方式 See: https://github.com/linuxdeepin/dtkdeclarative/commit/a9701858155b7118bfb53b6f241e35b9f6c0f15e
-if(${DtkDeclarativeModule_VERSION} VERSION_LESS "5.6.3")
-  set(DTK_OLD_VERSION True)
+# Map to DTK version (Qt6->DTK6, Qt5->DTK5)
+if(QT_VERSION_MAJOR MATCHES 6)
+    set(DTK_VERSION_MAJOR 6)
+else()
+    set(DTK_VERSION_MAJOR "")
 endif()
+message(STATUS "Build with DTK: ${DTK_VERSION_MAJOR}")
+
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Quick DBus)
+find_package(Dtk${DTK_VERSION_MAJOR}Declarative REQUIRED)
 
 add_definitions(-DAPP_VERSION="${APP_VERSION}")
 add_subdirectory(src)
 add_subdirectory(3rdparty/apiserver/client)
 
-set(ENV{QT_SELECT} qt5)
+set(ENV{QT_SELECT} qt${QT_VERSION_MAJOR})
 execute_process(COMMAND bash "-c" "lrelease translations/**/*"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Application
 include(GNUInstallDirs)
-set(DTK_QML_APP_PLUGIN_PATH ${CMAKE_INSTALL_LIBDIR}/dtkdeclarative/qml-app)
+
+# DTK6 exports DTK_QML_APP_PLUGIN_PATH from its cmake config, use it if available
+if(NOT DTK_QML_APP_PLUGIN_PATH)
+    set(DTK_QML_APP_PLUGIN_PATH ${CMAKE_INSTALL_LIBDIR}/dtkdeclarative/qml-app)
+endif()
 add_definitions(-DAPP_PLUGIN_PATH="${DTK_QML_APP_PLUGIN_PATH}")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(API)
 add_library(${PROJECT_NAME}
         api.h

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -65,7 +65,7 @@ T API::waitSignal(const typename QtPrivate::FunctionPointer<Func1>::Object *send
     });
     connect(sender, errSignal, &loop, [this, &loop, &exp](auto *worker, auto err_type, auto err_str) {
         exp.err_code = worker->getHttpResponseCode();
-        exp.err_type = err_type;
+        exp.err_type = QString::number(static_cast<int>(err_type));
         exp.err_msg = err_str;
         if (exp.err_code == 0) {
             exp.err_code = -1;

--- a/src/dbusservice/com.deepin.deepinid.Client.xml
+++ b/src/dbusservice/com.deepin.deepinid.Client.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="com.deepin.deepinid.Client">
+<node name="/com/deepin/deepinid/Client">
   <interface name="com.deepin.deepinid.Client">
     <signal name="loadError">
     </signal>

--- a/src/dbusservice/com.deepin.deepinid.xml
+++ b/src/dbusservice/com.deepin.deepinid.xml
@@ -1,12 +1,12 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 	 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="com.deepin.deepinid">
+<node name="/com/deepin/deepinid">
 	<interface name="com.deepin.deepinid">
 		<method name="Login"></method>
 		<method name="Logout"></method>
 		<property name="HardwareID" type="s" access="read"></property>
 		<property name="IsLogin" type="b" access="read"></property>
-		<property name="UserInfo" type="{sv}" access="read">
+		<property name="UserInfo" type="a{sv}" access="read">
 			<annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
 		</property>
 	</interface>

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -8,9 +8,6 @@ add_definitions(-DAPP_NAME="${APP_NAME}")
 add_definitions(-DAPP_DAEMON_NAME="${APP_DAEMON_NAME}")
 add_definitions(-DAPP_BIN_INSTALL_DIR="${APP_BIN_INSTALL_DIR}")
 
-if(${DTK_OLD_VERSION})
-  add_definitions(-DDTK_OLD_VERSION)
-endif()
 ###! main目录创建出二进制可执行文件，但启动方式由 DAppLoader
 ###! 中提供, 请不要在 main 中实现额外内容，请将需要实现的部分
 ###! 移动到 preload 插件和 maincomponent 插件中。
@@ -29,36 +26,36 @@ set(DAEMON_SRC
     ../../translations/deepin-home-daemon.qrc
     )
 
-# Find the Qt5Quick library
-find_package(Qt5Quick CONFIG REQUIRED)
-find_package(Qt5DBus CONFIG REQUIRED)
-find_package(Qt5Widgets CONFIG REQUIRED)
+# Find Qt libraries
+find_package(Qt${QT_VERSION_MAJOR}Quick CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}DBus CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Widgets CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)
 
 # 通过 dbus 接口的 xml 描述文件，生成调用dbus的 cpp 代码
 set_source_files_properties(../dbusservice/org.freedesktop.DBus.Properties.xml PROPERTIES CLASSNAME PropertiesChangedProxy)
 set_source_files_properties(../dbusservice/org.freedesktop.DBus.Properties.xml PROPERTIES NO_NAMESPACE ON)
-qt5_add_dbus_interface(DAEMON_SRC ../dbusservice/org.freedesktop.DBus.Properties.xml propertiesChangedProxy)
+qt_add_dbus_interface(DAEMON_SRC ../dbusservice/org.freedesktop.DBus.Properties.xml propertiesChangedProxy)
 
 set_source_files_properties(../dbusservice/org.desktopspec.ApplicationManager1.Application.xml PROPERTIES CLASSNAME ApplicationManager1Application)
 set_source_files_properties(../dbusservice/org.desktopspec.ApplicationManager1.Application.xml PROPERTIES NO_NAMESPACE ON)
-qt5_add_dbus_interface(DAEMON_SRC ../dbusservice/org.desktopspec.ApplicationManager1.Application.xml applicationManager1Application)
+qt_add_dbus_interface(DAEMON_SRC ../dbusservice/org.desktopspec.ApplicationManager1.Application.xml applicationManager1Application)
 
 set_source_files_properties(../dbusservice/com.deepin.deepinid.xml PROPERTIES CLASSNAME DeepinidDaemonProxy)
 set_source_files_properties(../dbusservice/com.deepin.deepinid.xml PROPERTIES NO_NAMESPACE ON)
-qt5_add_dbus_interface(DAEMON_SRC ../dbusservice/com.deepin.deepinid.xml deepinidDaemonProxy)
+qt_add_dbus_interface(DAEMON_SRC ../dbusservice/com.deepin.deepinid.xml deepinidDaemonProxy)
 
 set_source_files_properties(../dbusservice/com.deepin.deepinid.Client.xml PROPERTIES CLASSNAME DeepinidClientProxy)
 set_source_files_properties(../dbusservice/com.deepin.deepinid.Client.xml PROPERTIES NO_NAMESPACE ON)
-qt5_add_dbus_interface(DAEMON_SRC ../dbusservice/com.deepin.deepinid.Client.xml deepinidClientProxy)
+qt_add_dbus_interface(DAEMON_SRC ../dbusservice/com.deepin.deepinid.Client.xml deepinidClientProxy)
 
 set_source_files_properties(../dbusservice/com.deepin.Home.Daemon.xml PROPERTIES CLASSNAME HomeDaemonProxy)
-qt5_add_dbus_interface(SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemonProxy)
+qt_add_dbus_interface(SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemonProxy)
 
 # 通过 dbus 接口的 xml 描述文件，生成 Adaptor 类，使用 Adaptor 可以选择性的暴露类接口到 dbus
 # 可使用 qdbuscpp2xml 生成类的 xml 描述文件，再通过修改 xml 来隐藏部分接口
 # daemon 的 xml 描述文件生成： qdbuscpp2xml "src/main/homeDaemon.h" "-o" "src/dbusservice/com.deepin.Home.Daemon.xml"
-qt5_add_dbus_adaptor(DAEMON_SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemon.h HomeDaemon homeDaemonAdaptor HomeDaemonAdaptor)
+qt_add_dbus_adaptor(DAEMON_SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemon.h HomeDaemon homeDaemonAdaptor HomeDaemonAdaptor)
 
 # Add Client EXE
 add_executable(${APP_NAME} ${SRC})
@@ -67,15 +64,15 @@ add_executable(${APP_DAEMON_NAME} ${DAEMON_SRC})
 
 # 由于 EXE 只是作为启动程序加载 LIB 使用，一般来说，只需链接 ${LIB_NAME} 既可。
 target_link_libraries(${APP_NAME}
-    Qt5::Quick
-    Qt5::DBus
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::DBus
     ${DtkDeclarative_LIBRARIES}
     )
 target_link_libraries(${APP_DAEMON_NAME}
-    Qt5::Core
-    Qt5::Network
-    Qt5::DBus
-    Qt5::Widgets
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Widgets
     OpenSSL::SSL
     API
     )

--- a/src/main/account.cpp
+++ b/src/main/account.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -30,7 +30,7 @@ Account::Account(QObject *parent, API *api, QString server)
         // 跟随deepinid退出登陆
         if (!m_deepinidDaemon->isLogin()) {
             this->m_isLogin = false;
-            this->m_token = false;
+            this->m_token.clear();
             emit this->userInfoChanged();
             return;
         }

--- a/src/main/daemon.cpp
+++ b/src/main/daemon.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -14,7 +14,10 @@ int main(int argc, char *argv[])
     // daemon也使用client的应用名
     QApplication::setApplicationName(APP_NAME);
     QApplication::setApplicationVersion(APP_VERSION);
+    // Qt6中高DPI缩放默认启用，此属性已废弃
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
     QApplication app(argc, argv);
 
     QTranslator translator;

--- a/src/main/homeDaemon.cpp
+++ b/src/main/homeDaemon.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -415,7 +415,7 @@ QStringList HomeDaemon::getToken(QString publicKey)
 {
     qCDebug(logger) << "get token";
 #ifndef QT_DEBUG
-    auto pid = connection().interface()->servicePid(message().service());
+    auto pid = connection().interface()->servicePid(message().service()).value();
     qCDebug(logger) << "sender pid" << pid;
     auto sender = QFile::symLinkTarget(QString("/proc/%1/exe").arg(pid));
     if (sender != QString("%1%2").arg(APP_BIN_INSTALL_DIR).arg(APP_NAME)) {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -26,33 +26,17 @@ int main(int argc, char *argv[])
         qDebug() << "Register DBus Error" << dbus.lastError().message() << "Process may already be running.";
         return -1;
     }
-// 兼容旧版本 DtkDeclarative
-#ifdef DTK_OLD_VERSION
-    #ifdef LOCALLIBPATH
-        DAppLoader appLoader(APP_NAME, LOCALLIBPATH);
-    #else
-        DAppLoader appLoader(APP_NAME);
-    #endif
-#else
-    // 避免窗口菜单背景显示灰色 https://github.com/linuxdeepin/dtk/issues/70
-    // 在v20.9会导致菜单延迟显示，所以只在v23使用
     qputenv("D_POPUP_MODE", "embed");
-    // dtk 在新版本修改了 PLUGIN_PATH 的路径
-    // 为避免在旧版本 dtk 中无法使用，将旧的 PLUGIN_PATH 传递到 appLoader
-    // 如果传递的路径不存在 DAppLoader 内部会 feedback 到新路径，实现了新旧 dtk 兼容
-    auto oldPath=QDir(DTK_QML_APP_PLUGIN_PATH);
-    oldPath.cd("../plugins");
-    DAppLoader appLoader(APP_NAME, oldPath.path());
-    appLoader.addPluginPath(oldPath.path());
-    #ifdef PLUGINPATH
-        appLoader.addPluginPath(PLUGINPATH);
-    #endif
-    #ifdef APP_PLUGIN_PATH
-        appLoader.addPluginPath(APP_PLUGIN_PATH);
-    #endif
-    #ifdef LOCALLIBPATH
-        appLoader.addPluginPath(LOCALLIBPATH);
-    #endif
+    DAppLoader appLoader(APP_NAME, DTK_QML_APP_PLUGIN_PATH);
+    appLoader.addPluginPath(DTK_QML_APP_PLUGIN_PATH);
+#ifdef PLUGINPATH
+    appLoader.addPluginPath(PLUGINPATH);
+#endif
+#ifdef APP_PLUGIN_PATH
+    appLoader.addPluginPath(APP_PLUGIN_PATH);
+#endif
+#ifdef LOCALLIBPATH
+    appLoader.addPluginPath(LOCALLIBPATH);
 #endif
     return appLoader.exec(argc, argv);
 }

--- a/src/maincomponentplugin/CMakeLists.txt
+++ b/src/maincomponentplugin/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(${DTK_OLD_VERSION})
-    set(MAINCOMPONENT_LIB_NAME dtkqml-${CMAKE_PROJECT_NAME})
-else()
-    set(MAINCOMPONENT_LIB_NAME ${CMAKE_PROJECT_NAME}-main)
-endif()
+set(MAINCOMPONENT_LIB_NAME ${CMAKE_PROJECT_NAME}-main)
 set(MAINCOMPONENNT_SRC
     maincomponentplugin.h
     maincomponentplugin.cpp
@@ -13,16 +9,23 @@ set(MAINCOMPONENNT_SRC
     apiproxy.h
     apiproxy.cpp
 )
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
-find_package(Qt5QuickCompiler REQUIRED)
-find_package(Qt5DBus CONFIG REQUIRED)
-find_package(Qt5Concurrent CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR}DBus CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Concurrent CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)
 
 set_source_files_properties(../dbusservice/com.deepin.Home.Daemon.xml PROPERTIES CLASSNAME HomeDaemonProxy)
-qt5_add_dbus_interface(MAINCOMPONENNT_SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemonProxy)
+qt_add_dbus_interface(MAINCOMPONENNT_SRC ../dbusservice/com.deepin.Home.Daemon.xml homeDaemonProxy)
 
-qtquick_compiler_add_resources(MAINCOMPONENT_RCC_SOURCES maincomponent.qrc)
+# Qt5 uses qtquick_compiler_add_resources for AOT compilation,
+# Qt6 uses qt_add_resources
+if(QT_VERSION_MAJOR EQUAL 5)
+    find_package(Qt5QuickCompiler REQUIRED)
+    qtquick_compiler_add_resources(MAINCOMPONENT_RCC_SOURCES maincomponent.qrc)
+else()
+    qt_add_resources(MAINCOMPONENT_RCC_SOURCES maincomponent.qrc)
+endif()
+
 include_directories(src/maincomponentplugin)
 add_library(${MAINCOMPONENT_LIB_NAME} SHARED
     ${MAINCOMPONENNT_SRC}
@@ -33,14 +36,12 @@ target_include_directories(${MAINCOMPONENT_LIB_NAME}
     ${DTKDECLARATIVE_INCLUDE_DIR}
 )
 target_link_libraries(${MAINCOMPONENT_LIB_NAME}
-    Qt5::Quick
-    Qt5::Widgets
-    Qt5::DBus
-    Qt5::Concurrent
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Concurrent
     OpenSSL::SSL
     ${DtkDeclarative_LIBRARIES}
     API
 )
 install(TARGETS ${MAINCOMPONENT_LIB_NAME} DESTINATION ${DTK_QML_APP_PLUGIN_PATH})
-
-

--- a/src/maincomponentplugin/article/Article.qml
+++ b/src/maincomponentplugin/article/Article.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,7 +6,7 @@ import APIProxy 1.0
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
 import "../api"
 import "../widgets"

--- a/src/maincomponentplugin/feedback/Submit.qml
+++ b/src/maincomponentplugin/feedback/Submit.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 import "../api"
 import "../router"
 import APIProxy 1.0
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.11
 import QtQuick.Controls 2.4
-import QtQuick.Dialogs 1.0
+import QtQuick.Dialogs
 import QtQuick.Layouts 1.7
 import org.deepin.dtk 1.0
 
@@ -339,11 +339,11 @@ Item {
                             id: fileDialog
 
                             title: "Please choose a file"
-                            folder: shortcuts.home
                             selectMultiple: true
                             nameFilters: [qsTr("Image files") + " (*.png *.jpg *.gif)"]
                             onAccepted: {
-                                for (const f of fileDialog.fileUrls) {
+                                var files = typeof selectedFiles !== "undefined" ? selectedFiles : fileUrls;
+                                for (const f of files) {
                                     root.appendImage(f);
                                 }
                             }

--- a/src/maincomponentplugin/index/Card1.qml
+++ b/src/maincomponentplugin/index/Card1.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,7 +6,7 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
 
 Control {

--- a/src/maincomponentplugin/index/Card2.qml
+++ b/src/maincomponentplugin/index/Card2.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,7 +6,7 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
 
 Control {

--- a/src/maincomponentplugin/index/Card3.qml
+++ b/src/maincomponentplugin/index/Card3.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,7 +6,7 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.7
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import org.deepin.dtk 1.0
 
 Control {

--- a/src/maincomponentplugin/index/Index.qml
+++ b/src/maincomponentplugin/index/Index.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 import "../api"
@@ -7,7 +7,7 @@ import "../list" as DList
 import "../router"
 import "../widgets"
 import APIProxy 1.0
-import QtGraphicalEffects 1.0
+import Qt5Compat.GraphicalEffects
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.15

--- a/src/maincomponentplugin/widgets/Avatar.qml
+++ b/src/maincomponentplugin/widgets/Avatar.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 import QtQuick 2.11
 import QtQuick.Controls 2.4
-import QtGraphicalEffects 1.15
+import Qt5Compat.GraphicalEffects
 
 Image {
     id: img

--- a/src/maincomponentplugin/worker.cpp
+++ b/src/maincomponentplugin/worker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -225,7 +225,12 @@ QMap<QString, QVariant> Worker::getFileInfo(QString filepath)
 
 QString Worker::sysVersion()
 {
+    // minorVersion() 仅在 Linux 上可用，Windows 上使用 productVersion()
+#ifdef Q_OS_LINUX
     return Dtk::Core::DSysInfo::minorVersion();
+#else
+    return Dtk::Core::DSysInfo::productVersion();
+#endif
 }
 
 void Worker::notify(QString title, QString message)

--- a/src/preloadplugin/CMakeLists.txt
+++ b/src/preloadplugin/CMakeLists.txt
@@ -1,20 +1,24 @@
-if(${DTK_OLD_VERSION})
-    set(PRELOAD_LIB_NAME dtkqml-${CMAKE_PROJECT_NAME}-Preload)
-else()
-    set(PRELOAD_LIB_NAME ${CMAKE_PROJECT_NAME}-preload)
-endif()
+set(PRELOAD_LIB_NAME ${CMAKE_PROJECT_NAME}-preload)
 set(PRELOAD_SRC
     preloadplugin.cpp
     )
-find_package(Qt5QuickCompiler REQUIRED)
-qtquick_compiler_add_resources(PRELOAD_RCC_SOURCES preload.qrc)
+
+# Qt5 uses qtquick_compiler_add_resources for AOT compilation,
+# Qt6 uses qt_add_resources
+if(QT_VERSION_MAJOR EQUAL 5)
+    find_package(Qt5QuickCompiler REQUIRED)
+    qtquick_compiler_add_resources(PRELOAD_RCC_SOURCES preload.qrc)
+else()
+    qt_add_resources(PRELOAD_RCC_SOURCES preload.qrc)
+endif()
+
 include_directories(src/preloadplugin)
 add_library(${PRELOAD_LIB_NAME} SHARED
     ${PRELOAD_SRC}
     ${PRELOAD_RCC_SOURCES}
     )
 target_link_libraries(${PRELOAD_LIB_NAME}
-    Qt5::Quick
+    Qt${QT_VERSION_MAJOR}::Quick
     ${DtkDeclarative_LIBRARIES}
     )
 install(TARGETS ${PRELOAD_LIB_NAME} DESTINATION ${DTK_QML_APP_PLUGIN_PATH})

--- a/src/preloadplugin/preloadplugin.cpp
+++ b/src/preloadplugin/preloadplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -29,8 +29,10 @@ QGuiApplication *PreloadPlugin::creatApplication(int &argc, char **argv)
     app->setOrganizationName("deepin");
     app->setOrganizationDomain("deepin.org");
     app->setApplicationVersion(APP_VERSION);
-    // 高分屏
+    // 高分屏 (Qt6中高分屏默认启用，此属性已废弃)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     app->setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
     // 加载翻译
     auto translator = new QTranslator(app);
     if (translator->load(QLocale::system().name(), ":/resources/deepin-home/")) {


### PR DESCRIPTION
- CMake: auto-detect Qt5/Qt6, dynamically map DTK version
- CMake: replace hardcoded Qt5 with Qt${QT_VERSION_MAJOR}
- CMake: qt5_add_dbus_* → qt_add_dbus_* for Qt6 compat
- CMake: conditional qtquick_compiler_add_resources vs qt_add_resources
- CMake: remove DTK_OLD_VERSION compat logic
- main.cpp: simplify DAppLoader init, remove old DTK branches
- daemon.cpp/preloadplugin.cpp: guard deprecated Qt6 attributes
- api.cpp: explicit cast QNetworkReply::NetworkError to QString
- account.cpp: use m_token.clear() to fix Qt6 type mismatch
- homeDaemon.cpp: explicit .value() on QDBusReply
- D-Bus XML: fix node name to object path format
- D-Bus XML: change UserInfo type from {sv} to a{sv}
- worker.cpp: conditional DSysInfo::minorVersion() per platform
- QML: QtGraphicalEffects → Qt5Compat.GraphicalEffects
- QML: QtQuick.Dialogs remove version, FileDialog API compat

feat: 适配 DTK6/Qt6 编译

- CMake: 支持 Qt5/Qt6 自动检测，DTK 版本动态映射
- CMake: 所有 Qt5 硬编码改为 Qt${QT_VERSION_MAJOR} 动态引用
- CMake: qt5_add_dbus_* 改为 qt_add_dbus_*，兼容 Qt6
- CMake: qtquick_compiler_add_resources 按 Qt 版本条件选择
- CMake: 移除 DTK_OLD_VERSION 兼容逻辑
- main.cpp: 简化 DAppLoader 初始化，移除旧版 DTK 分支
- daemon.cpp/preloadplugin.cpp: Qt6 废弃属性加条件守卫
- api.cpp: QNetworkReply::NetworkError 显式转 QString
- account.cpp: m_token 赋值改用 clear()，修复 Qt6 类型不匹配
- homeDaemon.cpp: QDBusReply 显式调用 .value()
- D-Bus XML: node name 改为对象路径格式
- D-Bus XML: UserInfo 属性类型 {sv} 改为 a{sv}
- worker.cpp: DSysInfo::minorVersion() 按平台条件编译
- QML: QtGraphicalEffects → Qt5Compat.GraphicalEffects
- QML: QtQuick.Dialogs 移除版本号，FileDialog API 兼容

## Summary by Sourcery

Adapt build and runtime for DTK6/Qt6 while preserving Qt5 compatibility.

New Features:
- Support building against both Qt5 and Qt6 with automatic version detection and DTK version mapping.

Bug Fixes:
- Fix type mismatches and API usage issues in Qt6, including network error handling, token clearing, and QDBusReply access.
- Correct D-Bus XML object paths and UserInfo type to match expected Qt/DBus bindings.
- Ensure high DPI attributes are only set on Qt versions where they are supported.

Enhancements:
- Simplify DAppLoader initialization and remove legacy DTK compatibility branches.
- Update QML imports to use Qt5Compat.GraphicalEffects and QtQuick.Dialogs without versioned imports for Qt6 compatibility.
- Make DSysInfo-based system version retrieval platform-aware to work on both Linux and Windows.

Build:
- Raise CMake minimum version to 3.13 for API-related projects.
- Replace Qt5-specific CMake find_package and qt5_add_dbus_* calls with Qt-major-version-agnostic Qt${QT_VERSION_MAJOR} and qt_add_dbus_* macros.
- Use conditional qtquick_compiler_add_resources vs qt_add_resources based on Qt version and rely on DTK-exported plugin path when available.
- Remove DTK_OLD_VERSION-based build logic and standardize plugin library naming across components.

Documentation:
- Update SPDX copyright years across multiple source and QML files to cover 2022–2026.